### PR TITLE
Add DumpCommandHandler

### DIFF
--- a/src/main/kotlin/io/runescript/plugin/lang/psi/refs/RsDynamicExpressionReference.kt
+++ b/src/main/kotlin/io/runescript/plugin/lang/psi/refs/RsDynamicExpressionReference.kt
@@ -10,6 +10,7 @@ import io.runescript.plugin.lang.psi.RsScript
 import io.runescript.plugin.lang.psi.scope.RsLocalVariableResolver
 import io.runescript.plugin.lang.psi.scope.RsResolveMode
 import io.runescript.plugin.lang.psi.scope.RsScopesUtil
+import io.runescript.plugin.lang.psi.type.RsAnyType
 import io.runescript.plugin.lang.psi.type.RsPrimitiveType
 import io.runescript.plugin.lang.psi.type.RsType
 import io.runescript.plugin.lang.psi.type.trigger.RsTriggerType
@@ -62,6 +63,11 @@ class RsDynamicExpressionReference(element: RsDynamicExpression) :
             val project = element.project
             if (type is RsPrimitiveType) {
                 val resolvedConfig = RsSymbolIndex.lookup(element, type, elementName)
+                if (resolvedConfig != null) {
+                    return arrayOf(PsiElementResolveResult(resolvedConfig))
+                }
+            } else if (type == RsAnyType) {
+                val resolvedConfig = RsSymbolIndex.lookupAny(element, elementName)
                 if (resolvedConfig != null) {
                     return arrayOf(PsiElementResolveResult(resolvedConfig))
                 }

--- a/src/main/kotlin/io/runescript/plugin/lang/psi/type/RsAnyType.kt
+++ b/src/main/kotlin/io/runescript/plugin/lang/psi/type/RsAnyType.kt
@@ -1,0 +1,6 @@
+package io.runescript.plugin.lang.psi.type
+
+object RsAnyType : RsType {
+    override val representation: String
+        get() = "any"
+}

--- a/src/main/kotlin/io/runescript/plugin/lang/psi/type/inference/RsTypeInferenceVisitor.kt
+++ b/src/main/kotlin/io/runescript/plugin/lang/psi/type/inference/RsTypeInferenceVisitor.kt
@@ -725,6 +725,7 @@ private fun RsScript.findCommandHandler(): CommandHandler {
         "db_find_refine" -> DbFindCommandHandler.DB_FIND_REFINE
         "db_find_refine_with_count" -> DbFindCommandHandler.DB_FIND_REFINE_WITH_COUNT
         "db_getfield" -> DbGetFieldCommandHandler
+        "dump" -> DumpCommandHandler
         else -> DefaultCommandHandler
     }
 }

--- a/src/main/kotlin/io/runescript/plugin/symbollang/psi/index/RsSymbolIndex.kt
+++ b/src/main/kotlin/io/runescript/plugin/symbollang/psi/index/RsSymbolIndex.kt
@@ -33,6 +33,13 @@ class RsSymbolIndex : StringStubIndexExtension<RsSymSymbol>() {
             }
         }
 
+        fun lookupAny(context: PsiElement, name: String): RsSymSymbol? {
+            val module = ModuleUtil.findModuleForPsiElement(context) ?: return null
+            val scope = GlobalSearchScope.moduleScope(module)
+            val configs = StubIndex.getElements(KEY, name, context.project, scope, RsSymSymbol::class.java)
+            return configs.firstOrNull()
+        }
+
         val PsiFile.nameWithoutExtension: String
             get() {
                 val dot = name.lastIndexOf('.')


### PR DESCRIPTION
Introduces the handler for the `dump` command that the compiler supports. This adds a `RsAnyType` which is used when attempting to resolve `RsDynamicExpression`s without any concrete type. Current implementation will resolve to the first result by the given name, I think I would like to change this on the compiler side to eventually error if there is ambiguity (2 or more potential resolutions). 